### PR TITLE
Mark dir safe for git

### DIFF
--- a/ci/Dockerfile
+++ b/ci/Dockerfile
@@ -38,6 +38,8 @@ RUN echo "${USER_NAME}:x:${USER_UID}:0:${USER_NAME} user:${HOME}:/sbin/nologin" 
  && chown -R "${USER_UID}:0" /go \
  && chmod -R ug+rwX /go
 
+RUN git config --system --add safe.directory /opt/ansible
+
 # Copy application files (must be separate from RUN)
 COPY . /opt/ansible
 


### PR DESCRIPTION
Adds a command in Dockerfile to fixe the following flake:

FATAL: Command "git ls-files -z --cached --others --exclude-standard" returned exit status 128.
>>> Standard Error
fatal: detected dubious ownership in repository at '/opt/ansible' To add an exception for this directory, call:
	git config --global --add safe.directory /opt/ansible